### PR TITLE
Fix issues counted by coverity metrics.

### DIFF
--- a/src/main/java/org/sonar/plugins/coverity/batch/CoveritySensor.java
+++ b/src/main/java/org/sonar/plugins/coverity/batch/CoveritySensor.java
@@ -44,6 +44,8 @@ import java.util.Map;
 import org.sonar.plugins.coverity.util.*;
 import org.sonar.plugins.coverity.ws.TripleFromDefects;
 
+import javax.xml.datatype.DatatypeConfigurationException;
+
 import static org.sonar.plugins.coverity.base.CoverityPluginMetrics.*;
 import static org.sonar.plugins.coverity.util.CoverityUtil.createURL;
 
@@ -129,9 +131,28 @@ public class CoveritySensor implements Sensor {
             LOG.debug(ar.toString());
         }
 
+        javax.xml.datatype.XMLGregorianCalendar analysisDate = null;
+        if (project.getAnalysisDate() != null) {
+          try {
+            java.util.GregorianCalendar gcal = new java.util.GregorianCalendar();
+            gcal.setTime(project.getAnalysisDate());
+            analysisDate = javax.xml.datatype.DatatypeFactory.newInstance().newXMLGregorianCalendar(gcal);
+          } catch (DatatypeConfigurationException e) {
+            LOG.error("Could not convert date: " + project.getAnalysisDate());
+            Thread.currentThread().setContextClassLoader(oldCL);
+            return;
+          }
+        }
+
         try {
             LOG.info("Fetching defects for project: " + covProject);
-            List<MergedDefectDataObj> defects = instance.getDefects(covProject);
+
+            MergedDefectFilterSpecDataObj filter = new MergedDefectFilterSpecDataObj();
+            if (analysisDate != null) {
+                //get only the defects introduced before the specified date
+                filter.setFirstDetectedEndDate(analysisDate);
+            }
+            List<MergedDefectDataObj> defects = instance.getDefects(covProject, filter);
 
             Map<Long, StreamDefectDataObj> streamDefects = instance.getStreamDefectsForMergedDefects(defects);
 
@@ -139,8 +160,17 @@ public class CoveritySensor implements Sensor {
 
             for(MergedDefectDataObj mddo : defects) {
                 String status = mddo.getStatus();
-                if ("Dismissed".equals(status) || "Fixed".equals(status)) {
-                  LOG.info("Skipping resolved defect (CID " + mddo.getCid() + ", status '" + mddo.getStatus() + "')");
+
+                //Skip dismissed defects
+                if ("Dismissed".equals(status)) {
+                  LOG.info("Skipping dismissed defect (CID " + mddo.getCid() + "')");
+                  continue;
+                }
+
+                //Skip fixed defects (but keep them if they were fixed after specified date)
+                if ("Fixed".equals(status) &&
+                    (analysisDate == null || mddo.getLastDetected().compare(analysisDate) <= 0)) {
+                  LOG.info("Skipping fixed defect (CID " + mddo.getCid() + "')");
                   continue;
                 }
 

--- a/src/main/java/org/sonar/plugins/coverity/ws/CIMClient.java
+++ b/src/main/java/org/sonar/plugins/coverity/ws/CIMClient.java
@@ -203,6 +203,25 @@ public class CIMClient {
         return result;
     }
 
+    public List<MergedDefectDataObj> getDefects(String project, MergedDefectFilterSpecDataObj filterSpec) throws IOException, CovRemoteServiceException_Exception {
+      ProjectIdDataObj projectId = new ProjectIdDataObj();
+      projectId.setName(project);
+      PageSpecDataObj pageSpec = new PageSpecDataObj();
+      pageSpec.setPageSize(2500);
+
+      List<MergedDefectDataObj> result = new ArrayList<MergedDefectDataObj>();
+      int defectCount = 0;
+      MergedDefectsPageDataObj defects = null;
+      do {
+        pageSpec.setStartIndex(defectCount);
+        defects = getDefectService().getMergedDefectsForProject(projectId, filterSpec, pageSpec);
+        result.addAll(defects.getMergedDefects());
+        defectCount += defects.getMergedDefects().size();
+      } while(defectCount < defects.getTotalNumberOfRecords());
+
+      return result;
+    }
+
     public ProjectDataObj getProject(String projectId) throws IOException, CovRemoteServiceException_Exception {
         ProjectFilterSpecDataObj filterSpec = new ProjectFilterSpecDataObj();
         filterSpec.setNamePattern(projectId);


### PR DESCRIPTION
- Count only outstanding issues: issues which are neither fixed nor dismissed.
- Filtering issues to present only issues opened at the analysis date. This is useful to populate Sonar with past data when a project is created.
