### PR TITLE
Rewrite coverity widget & metrics.

### DIFF
--- a/src/main/java/org/sonar/plugins/coverity/base/CoverityPluginMetrics.java
+++ b/src/main/java/org/sonar/plugins/coverity/base/CoverityPluginMetrics.java
@@ -23,59 +23,45 @@ public class CoverityPluginMetrics implements Metrics{
 
     public static String DOMAIN = new String("Coverity");
 
-    // This metric will contain the URL to CIM.
-    public static final Metric COVERITY_URL_CIM_METRIC = new Metric.Builder("COVERITY-URL-CIM-METRIC", "Url cim metric", Metric.ValueType.STRING)
-            .setDirection(Metric.DIRECTION_NONE)
-            .setQualitative(true)
-            .setDomain(DOMAIN)
-            .create();
-
     // This metric will contain the name of the project.
     public static final Metric COVERITY_PROJECT_NAME = new Metric.Builder("COVERITY-PROJECT-NAME", "Project Name", Metric.ValueType.STRING)
             .setDirection(Metric.DIRECTION_NONE)
-            .setQualitative(true)
-            .setDomain(DOMAIN)
-            .create();
-
-    // This metric will contain the URL to the project
-    public static final Metric COVERITY_PROJECT_URL = new Metric.Builder("COVERITY-PROJECT-URL", "Project Url", Metric.ValueType.STRING)
-            .setDirection(Metric.DIRECTION_NONE)
-            .setQualitative(true)
+            .setQualitative(false)
             .setDomain(DOMAIN)
             .create();
 
     // This metric will contain the total number of defects in the project.
     // This also counts defects for which the method getResourceForFile() returned null.
-    public static final Metric COVERITY_OUTSTANDING_ISSUES = new Metric.Builder("COVERITY-OUTSTANDING-ISSUES", "Outstanding Issues", Metric.ValueType.STRING)
-            .setDirection(Metric.DIRECTION_NONE)
+    public static final Metric COVERITY_OUTSTANDING_ISSUES = new Metric.Builder("COVERITY-OUTSTANDING-ISSUES", "Outstanding Issues", Metric.ValueType.INT)
+            .setDirection(Metric.DIRECTION_WORST)
             .setQualitative(true)
             .setDomain(DOMAIN)
             .create();
 
     // This metric will contain the number of defects with high impact.
-    public static final Metric COVERITY_HIGH_IMPACT  = new Metric.Builder("COVERITY-HIGH-IMPACT", "High Impact", Metric.ValueType.STRING)
+    public static final Metric COVERITY_HIGH_IMPACT  = new Metric.Builder("COVERITY-HIGH-IMPACT", "High Impact", Metric.ValueType.INT)
             .setDirection(Metric.DIRECTION_WORST)
-            .setQualitative(false)
+            .setQualitative(true)
             .setDomain(DOMAIN)
             .create();
 
     // This metric will contain the number of defects with medium impact.
-    public static final Metric COVERITY_MEDIUM_IMPACT  = new Metric.Builder("COVERITY-MEDIUM-IMPACT", "Medium Impact", Metric.ValueType.STRING)
+    public static final Metric COVERITY_MEDIUM_IMPACT  = new Metric.Builder("COVERITY-MEDIUM-IMPACT", "Medium Impact", Metric.ValueType.INT)
             .setDirection(Metric.DIRECTION_WORST)
-            .setQualitative(false)
+            .setQualitative(true)
             .setDomain(DOMAIN)
             .create();
 
     // This metric will contain the number of defects with low impact.
-    public static final Metric COVERITY_LOW_IMPACT  = new Metric.Builder("COVERITY-LOW-IMPACT", "Low Impact", Metric.ValueType.STRING)
+    public static final Metric COVERITY_LOW_IMPACT  = new Metric.Builder("COVERITY-LOW-IMPACT", "Low Impact", Metric.ValueType.INT)
             .setDirection(Metric.DIRECTION_WORST)
-            .setQualitative(false)
+            .setQualitative(true)
             .setDomain(DOMAIN)
             .create();
 
 
     public List<Metric> getMetrics() {
-        return Arrays.asList(COVERITY_URL_CIM_METRIC, COVERITY_PROJECT_NAME, COVERITY_PROJECT_URL, COVERITY_OUTSTANDING_ISSUES, COVERITY_HIGH_IMPACT,
+        return Arrays.asList(COVERITY_PROJECT_NAME, COVERITY_OUTSTANDING_ISSUES, COVERITY_HIGH_IMPACT,
                 COVERITY_MEDIUM_IMPACT, COVERITY_LOW_IMPACT);
     }
 }

--- a/src/main/java/org/sonar/plugins/coverity/batch/CoveritySensor.java
+++ b/src/main/java/org/sonar/plugins/coverity/batch/CoveritySensor.java
@@ -57,10 +57,10 @@ public class CoveritySensor implements Sensor {
     private final String MEDIUM = "Medium";
     private final String LOW = "Low";
 
-    private String totalDefects = null;
-    private String highImpactDefects = null;
-    private String mediumImpactDefects = null;
-    private String lowImpactDefects = null;
+    private int totalDefects;
+    private int highImpactDefects;
+    private int mediumImpactDefects;
+    private int lowImpactDefects;
 
     public CoveritySensor(Settings settings, RulesProfile profile, ResourcePerspectives resourcePerspectives) {
         this.settings = settings;
@@ -203,10 +203,10 @@ public class CoveritySensor implements Sensor {
             e.printStackTrace();
         }
 
-        totalDefects = String.valueOf(totalDefectsCounter);
-        highImpactDefects = String.valueOf(highImpactDefectsCounter);
-        mediumImpactDefects = String.valueOf(mediumImpactDefectsCounter);
-        lowImpactDefects = String.valueOf(lowImpactDefectsCounter);
+        totalDefects = totalDefectsCounter;
+        highImpactDefects = highImpactDefectsCounter;
+        mediumImpactDefects = mediumImpactDefectsCounter;
+        lowImpactDefects = lowImpactDefectsCounter;
 
         Thread.currentThread().setContextClassLoader(oldCL);
         // Display a clickable Coverity Logo
@@ -259,52 +259,40 @@ public class CoveritySensor implements Sensor {
     * saves the measures into sensorContext. This method is called by analyse().
     * */
     private void getCoverityLogoMeasures(SensorContext sensorContext, CIMClient client, ProjectDataObj covProjectObj) {
+        String projectUrl = createURL(client);
+        String productKey= String.valueOf(covProjectObj.getProjectKey());
+        projectUrl = projectUrl+"reports.htm#p"+productKey;
+
         {
             Measure measure = new Measure(COVERITY_PROJECT_NAME);
             String covProject = settings.getString(CoverityPlugin.COVERITY_PROJECT);
             measure.setData(covProject);
-            sensorContext.saveMeasure(measure);
-        }
-
-        {
-            Measure measure = new Measure(COVERITY_PROJECT_URL);
-            String ProjectUrl = createURL(client);
-            String ProductKey= String.valueOf(covProjectObj.getProjectKey());
-            ProjectUrl = ProjectUrl+"reports.htm#p"+ProductKey;
-            measure.setData(ProjectUrl);
-            sensorContext.saveMeasure(measure);
-        }
-
-        {
-            Measure measure = new Measure(COVERITY_URL_CIM_METRIC);
-            String ProjectUrl = createURL(client);
-            String ProductKey= String.valueOf(covProjectObj.getProjectKey());
-            ProjectUrl = ProjectUrl+"reports.htm#p"+ProductKey;
-            measure.setData(ProjectUrl);
+            measure.setUrl(projectUrl);
             sensorContext.saveMeasure(measure);
         }
 
         {
             Measure measure = new Measure(COVERITY_OUTSTANDING_ISSUES);
-            measure.setData(totalDefects);
+            measure.setIntValue(totalDefects);
+            measure.setUrl(projectUrl);
             sensorContext.saveMeasure(measure);
         }
 
         {
             Measure measure = new Measure(COVERITY_HIGH_IMPACT);
-            measure.setData(highImpactDefects);
+            measure.setIntValue(highImpactDefects);
             sensorContext.saveMeasure(measure);
         }
 
         {
             Measure measure = new Measure(COVERITY_MEDIUM_IMPACT);
-            measure.setData(mediumImpactDefects);
+            measure.setIntValue(mediumImpactDefects);
             sensorContext.saveMeasure(measure);
         }
 
         {
             Measure measure = new Measure(COVERITY_LOW_IMPACT);
-            measure.setData(lowImpactDefects);
+            measure.setIntValue(lowImpactDefects);
             sensorContext.saveMeasure(measure);
         }
     }

--- a/src/main/resources/org/sonar/plugins/coverity/ui/coverity-widget.html.erb
+++ b/src/main/resources/org/sonar/plugins/coverity/ui/coverity-widget.html.erb
@@ -1,3 +1,11 @@
+<%
+    outstanding_measure = @snapshot.measure('COVERITY-OUTSTANDING-ISSUES')
+    highimpact_measure = @snapshot.measure('COVERITY-HIGH-IMPACT')
+    mediumimpact_measure = @snapshot.measure('COVERITY-MEDIUM-IMPACT')
+    lowimpact_measure = @snapshot.measure('COVERITY-LOW-IMPACT')
+
+    if outstanding_measure || highimpact_measure || mediumimpact_measure || lowimpact_measure
+%>
 <style>
     .coverity-inner {
         font-style: normal;
@@ -10,97 +18,43 @@
         border: 0;
     }
 </style>
-<%
-=begin
-    In the following table we will use the method format_measure() repeatedly, this method requires the key of a measure
-    and also admits another optional parameters. If none of these parameters are specified it will return by default an
-    string with the data stored in the metric. This data will be enclosed under a <span> tag, which is why we need to
-    use the method gsub() in order to get the string enclosed by this tag.
-=end
-%>
 <table width="100%">
-    <tr>
-        <td width="10">
-                <a href='<%=
-                    # @return [String]
-                    mystring=format_measure('COVERITY-URL-CIM-METRIC', {:skip_span_id => true})
-                    mystring.gsub(/<span[^>]*>(.*)<\/span>/,'\1')
-                -%>'>
-
-                <img src="<%= url_for_static(:plugin => 'coverity', :path => 'coverity-logo.png') -%>" alt="Coverity Logo" >
-            </a>
-        </td>
-    </tr>
-    <tr>
-        <td>
-                <p><b>Coverity Project:</b>
-                <a href='<%=
-                    # @return [String]
-
-                    mystring1=format_measure('COVERITY-PROJECT-URL', {:skip_span_id => true})
-                    mystring1.gsub(/<span[^>]*>(.*)<\/span>/,'\1')
-                -%>'>
-                    <%=
-                        # @return [String]
-
-                        mystring2=format_measure('COVERITY-PROJECT-NAME', {:skip_span_id => true})
-                        mystring2.gsub(/<span[^>]*>(.*)<\/span>/,'\1')
-
-                    -%>
-                </a>
-                </p>
-                <br>
-        </td>
-    </tr>
-    <tr>
-        <td>
-                <p>Outstanding Issues:</p>
-                <p>
-                        <%=
-                            # @return [String]
-
-                            mystring3=format_measure('COVERITY-OUTSTANDING-ISSUES', {:skip_span_id => true})
-                            mystring3.gsub(/<span[^>]*>(.*)<\/span>/,'\1')
-
-                        -%>
-                </p>
-        </td>
-        <td>
-                <p>High Impact:</p>
-                <p>
-                    <%=
-                        # @return [String]
-
-                        mystring4=format_measure('COVERITY-HIGH-IMPACT', {:skip_span_id => true})
-                        mystring4.gsub(/<span[^>]*>(.*)<\/span>/,'\1')
-
-                    -%>
-                </p>
-        </td>
-        <td>
-                <p>Medium Impact:</p>
-                <p>
-                    <%=
-                        # @return [String]
-
-                        mystring5=format_measure('COVERITY-MEDIUM-IMPACT', {:skip_span_id => true})
-                        mystring5.gsub(/<span[^>]*>(.*)<\/span>/,'\1')
-
-                    -%>
-                </p>
-        </td>
-        <td>
-                <p>Low Impact:</p>
-                <p>
-                    <%=
-                        # @return [String]
-
-                        mystring6=format_measure('COVERITY-LOW-IMPACT', {:skip_span_id => true})
-                        mystring6.gsub(/<span[^>]*>(.*)<\/span>/,'\1')
-
-                    -%>
-                </p>
-        </td>
-    </tr>
+  <td width="50%" valign="top">
+    <div class="dashbox">
+	  <h3>Coverity Issues</h3>
+      <span class="big">
+        <p>
+          <%= format_measure(outstanding_measure, {:url => outstanding_measure.url}) -%>
+          <%= dashboard_configuration.selected_period? ? format_variation(outstanding_measure) : trend_icon(outstanding_measure) -%>
+        </p>
+      </span>
+    </div>
+  </td>
+  <td valign="top">
+    <div class="dashbox">
+      <p class="title">By Impact</p>
+      <table>
+        <%
+		  distribution = nil
+          [highimpact_measure, mediumimpact_measure, lowimpact_measure].each do |measure|
+            measure_name = measure.short_name.chomp(" Impact")
+            distribution = (distribution ? distribution + ";" : "") + measure_name + "=" + measure.value.to_s
+        %>
+          <tr>
+            <td align="left">
+              <%= measure_name -%>
+            </td>
+            <td align="right" style="padding-left: 10px;">
+              <%= format_measure(measure) -%>
+              <%= dashboard_configuration.selected_period? ? format_variation(measure) : trend_icon(measure) -%>
+            </td>
+          </tr>
+        <% end %>
+      </table>
+    </div>
+  </td>
+  <td valign="center">
+    <%= piechart( distribution ) -%>
+  </td>
 </table>
-
+<% end %>


### PR DESCRIPTION
- Metrics are now integers and qualitive, to allow tracking evolution.
- Widget gets a look similar to other widgets, with outstanding issues shown
  prominently and distribution by impact on the side.
- Support variation display.
- Cleanup management of links, by storing them in url field of the measure.
- A piechart is also present to graphically show the distribution.
