### PR TITLE
Fix plugin for coverity 4.2+.

### DIFF
--- a/src/main/java/org/sonar/plugins/coverity/batch/CoveritySensor.java
+++ b/src/main/java/org/sonar/plugins/coverity/batch/CoveritySensor.java
@@ -139,7 +139,7 @@ public class CoveritySensor implements Sensor {
 
             for(MergedDefectDataObj mddo : defects) {
                 String filePath = mddo.getFilePathname();
-                Resource res = getResourceForFile(filePath, project.getFileSystem());
+                Resource res = getResourceForFile(filePath, project);
 
                 TripleFromDefects tripleFromMddo = new TripleFromDefects(mddo.getCheckerName(),
                         mddo.getCheckerSubcategory(), mddo.getDomain());
@@ -236,16 +236,13 @@ public class CoveritySensor implements Sensor {
         return null;
     }
 
-    protected Resource getResourceForFile(String filePath, ProjectFileSystem fileSystem) {
+    protected Resource getResourceForFile(String filePath, Project project) {
         File f = new File(filePath);
-        Resource ret;
-        ret = org.sonar.api.resources.JavaFile.fromIOFile(f, fileSystem.getSourceDirs(), false);
-        if(ret == null) {
-            ret = org.sonar.api.resources.File.fromIOFile(f, fileSystem.getSourceDirs());
-        } else {
-            // LOG.info("java file! : " + ret);
+        Resource ret = org.sonar.api.resources.File.fromIOFile(f, project);
+        if (ret == null) {
+          // support SQ<4.2
+          ret = org.sonar.api.resources.File.fromIOFile(f, project.getFileSystem().getTestDirs());
         }
-
         return ret;
     }
 


### PR DESCRIPTION
The JavaFile.fromIOFile() now throws an exception, must use File.fromIOFile() instead.
The API was deprecated (but still working in 4.2), and has been removed in 4.3.
