### PR TITLE
Change name of repositories to fit more into Sonar ui.

### DIFF
--- a/src/main/java/org/sonar/plugins/coverity/server/CoverityRules.java
+++ b/src/main/java/org/sonar/plugins/coverity/server/CoverityRules.java
@@ -172,7 +172,7 @@ public class CoverityRules implements RulesDefinition, Extension {
         otherLanguages.add("c");
 
         for(String language : otherLanguages){
-            NewRepository repository = context.createRepository(CoverityPlugin.REPOSITORY_KEY + "-" + language, language).setName(language + "-repository");
+            NewRepository repository = context.createRepository(CoverityPlugin.REPOSITORY_KEY + "-" + language, language).setName("coverity-" + language);
             String fileDir = "coverity-cpp.xml";
             InputStream in = getClass().getResourceAsStream(fileDir);
             xmlLoader.load(repository, in, "UTF-8");
@@ -180,7 +180,7 @@ public class CoverityRules implements RulesDefinition, Extension {
         }
 
         for(String language : languages){
-            NewRepository repository = context.createRepository(CoverityPlugin.REPOSITORY_KEY + "-" + language, language).setName(language + "-repository");
+            NewRepository repository = context.createRepository(CoverityPlugin.REPOSITORY_KEY + "-" + language, language).setName("coverity-" + language);
             String fileDir = "coverity-" + language + ".xml";
             InputStream in = getClass().getResourceAsStream(fileDir);
             xmlLoader.load(repository, in, "UTF-8");


### PR DESCRIPTION
Repositories are now named "coverity-<LANGUAGE>" to make it easier to find the rules in Sonar UI.
