### PR TITLE
Fix SonarQube analysis on Windows systems.

### DIFF
--- a/src/test/java/org/sonar/plugins/coverity/batch/CoveritySensorTest.java
+++ b/src/test/java/org/sonar/plugins/coverity/batch/CoveritySensorTest.java
@@ -19,6 +19,7 @@ import com.coverity.ws.v6.ProjectDataObj;
 import org.junit.Before;
 import org.junit.Test;
 import org.sonar.api.batch.SensorContext;
+import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.component.ResourcePerspectives;
 import org.sonar.api.config.Settings;
 import org.sonar.api.measures.Measure;
@@ -42,14 +43,16 @@ public class CoveritySensorTest {
     RulesProfile profile;
     ResourcePerspectives resourcePerspectives;
     CoveritySensor sensor;
+    FileSystem fileSystem;
 
     @Before
     public void setUp() throws Exception {
         settings = mock(Settings.class);
         profile = mock(RulesProfile.class);
         resourcePerspectives = mock(ResourcePerspectives.class);
+        fileSystem = mock(FileSystem.class);
 
-        sensor = new CoveritySensor(settings, profile, resourcePerspectives);
+        sensor = new CoveritySensor(settings, profile, resourcePerspectives, fileSystem);
     }
 
     @Test


### PR DESCRIPTION
On Windows systems the SonarQube use backslashes in the path of resources,
but Coverity always store the filepath in unix style (with slash). If the
SonarQube Runner runs on Windows, then we have to change the path to unix
path, so the SonarQube can create the SonarQube issues from the Coverity
defects.
