### PR TITLE
Remove checking for active rules by coverity repository.

### DIFF
--- a/src/main/java/org/sonar/plugins/coverity/batch/CoveritySensor.java
+++ b/src/main/java/org/sonar/plugins/coverity/batch/CoveritySensor.java
@@ -71,8 +71,7 @@ public class CoveritySensor implements Sensor {
 
     public boolean shouldExecuteOnProject(Project project) {
         boolean enabled = settings.getBoolean(CoverityPlugin.COVERITY_ENABLE);
-        int active = profile.getActiveRulesByRepository(CoverityPlugin.REPOSITORY_KEY + "-" + project.getLanguageKey()).size();
-        return enabled && active > 0;
+        return enabled;
     }
 
     public void analyse(Project project, SensorContext sensorContext) {


### PR DESCRIPTION
Starting with SonarQube 4.2, multi-language projects are supported, in this case, sonar.language properties should NOT be set in order to trigger multi-language analysis.

But in this plugin, it use project.getLanguageKey() in below line:
int active = profile.getActiveRulesByRepository(CoverityPlugin.REPOSITORY_KEY + "-" + project.getLanguageKey()).size(); 

Then the value of active will always be false if used in multi-language project.

Suggest to remove the checking for active rules by coverity repository, then this plugin will work both for single language and multi-language projects.
